### PR TITLE
[Enhancement] Git Integration

### DIFF
--- a/.justfile
+++ b/.justfile
@@ -53,7 +53,7 @@ alias v    := valgrind
         -Wall -Werror -Wextra -Wpedantic \
         aliases/*.f \
         src/*.f \
-        -o target/ga-f18
+        -o target/git-aliases
 
 # Remove build and documentation artifacts.
 @clear:
@@ -71,12 +71,12 @@ alias v    := valgrind
 
 # Copy the target application to this user's path.
 @install: build
-    cp target/ga-f18 ~/.local/bin/
+    cp target/git-aliases ~/.local/bin/
 
 # Analyse the memory management of the target application.
 @valgrind: build
     valgrind \
         --leak-check=full --redzone-size=512 --show-leak-kinds=all \
-        ./target/ga-f18
+        ./target/git-aliases
 
 ################################################################################

--- a/README.md
+++ b/README.md
@@ -97,14 +97,20 @@ optional.
 
 ## Description
 
-This repository contains the source code of an application named `ga-f18`.  When
-compiled, it will configure the hard coded Git alias commands.  A common use
-case of this application is hence the initialisation of Git in a new user
+This repository contains the source code of an application named `git-aliases`.
+When compiled, it will configure the hard coded Git alias commands.  A common
+use case of this application is hence the initialisation of Git in a new user
 account.
 
-`ga-f18` can be freely expanded with further commands.  The procedure in order
-to do so is illustrated by the source files in the `aliases/` directory of this
-repository.
+`git-aliases` can be freely expanded with further commands.  The procedure in
+order to do so is illustrated by the source files in the `aliases/` directory
+of this repository.
+
+This tool can be integrated into Git, at option.  Due to its naming convention,
+Git will consider all applications prefixed with `git-` associated commands.
+This feature offers two benefits.  One can not only configure all desired alias
+commands with this tool but also request a summary for the aliases set up by
+this application with Git itself.
 
 When calling the application, it will show some default information about itself
 in the first five lines.  These information are about the application's name and

--- a/src/git-aliases-f18.f
+++ b/src/git-aliases-f18.f
@@ -25,7 +25,7 @@
 !> \copyright   (C) 2022 Kevin Matthes.
 !>              This file is licensed GPL 2 as of June 1991.
 !> \date        2022
-!> \file        ga-f18.f
+!> \file        git-aliases-f18.f
 !> \note        See `LICENSE' for full license.
 !>              See `README.md' for project details.
 !>
@@ -40,14 +40,20 @@
 !> \return  This program will return with exit code zero, by default.
 !>
 !> This program will invoke the configuration of the defined Git alias commands.
+!>
+!> Due to the naming convention of Git, this program can be integrated into it.
+!> Git will treat any applications prefixed with `git-` as associated commands.
+!> Doing so with this program is also a benefit for the user since one can not
+!> only configure all aliases with this tool but also request a summary of the
+!> aliases setup with this tool.
 !!
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
-      program ga_f18
+      program git_aliases_f18
       implicit none
 
       print '(a / a / a / a / a //// a20, t24, a /)'
-     &,     'ga-f18, version 0.1.0'
+     &,     'git-aliases, version 0.1.0'
      &,     'Copyright (C) 2022 Kevin Matthes.'
      &,     'This is free software according to GPL-2.0.'
      &,     'THERE IS ABSOLUTELY NO WARRANTY, WITHOUT EVEN THE IMPLIED '

--- a/src/git-aliases-f18.f
+++ b/src/git-aliases-f18.f
@@ -45,7 +45,7 @@
 !> Git will treat any applications prefixed with `git-` as associated commands.
 !> Doing so with this program is also a benefit for the user since one can not
 !> only configure all aliases with this tool but also request a summary of the
-!> aliases setup with this tool.
+!> aliases set up with this tool.
 !!
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 


### PR DESCRIPTION
Git has a naming convention similar to Cargo.  Prefixing applications with `git-` and placing them in the range of `$PATH` will cause Git to consider them associated commands.